### PR TITLE
use the twi_body for the message

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -27,6 +27,9 @@ public class RNPushNotificationListenerService extends GcmListenerService {
     @Override
     public void onMessageReceived(String from, final Bundle bundle) {
         JSONObject data = getPushData(bundle.getString("data"));
+        if (bundle.containsKey("twi_body")) {
+            bundle.putString("message", bundle.getString("twi_body"));
+        }
         if (data != null) {
             if (!bundle.containsKey("message")) {
                 bundle.putString("message", data.optString("alert", "Notification received"));


### PR DESCRIPTION
Twilio doesn't add the "message" (or "alert") property that rn-push-notification uses for the notification bar.
If there is a "twi_body" use that instead.